### PR TITLE
Update Client.php: fix updateAppSettings

### DIFF
--- a/lib/GetStream/StreamChat/Client.php
+++ b/lib/GetStream/StreamChat/Client.php
@@ -315,7 +315,7 @@ class Client
      */
     public function updateAppSettings($settings)
     {
-        return $this->patch("app");
+        return $this->patch("app", $settings);
     }
 
     /**


### PR DESCRIPTION
the settings were not passed as a parameter

# Submit a pull request

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [x] Code changes are tested (add some information if not applicable)
The automated tests don't cover this feature yet.
## Description of the pull request
added a missing parameter in the updateAppSettings patch call