### PR TITLE
feat: `restoreUsers` method for `Client.php`, update method comments in `Client.php`

### DIFF
--- a/lib/GetStream/StreamChat/Client.php
+++ b/lib/GetStream/StreamChat/Client.php
@@ -375,7 +375,7 @@ class Client
         return $this->partialUpdateUsers([$partialUpdate]);
     }
 
-    /** Deletes a user synchronously. For updating multiple users,
+    /** Deletes a user synchronously. For deleting multiple users,
      * use `$client->deleteUsers` instead.
      * @link https://getstream.io/chat/docs/php/update_users/?language=php
      * @throws StreamException
@@ -409,7 +409,7 @@ class Client
         return $this->post("users/restore", ["user_ids" => $userIds]);
     }
 
-    /** Deletes multiple users. This operation is asynchronous.
+    /** Deletes multiple channels. This operation is asynchronous.
      * Use `$client->getTask` to check the status of the task.
      * @link https://getstream.io/chat/docs/php/channel_delete/?language=php
      * @throws StreamException

--- a/lib/GetStream/StreamChat/Client.php
+++ b/lib/GetStream/StreamChat/Client.php
@@ -399,6 +399,16 @@ class Client
         return $this->post("users/delete", $options);
     }
 
+    /** Restores soft-deleted users. This operation is asynchronous.
+     * Use `$client->getTask` to check the status of the task.
+     * @link https://getstream.io/chat/docs/php/update_users/?language=php
+     * @throws StreamException
+     */
+    public function restoreUsers(array $userIds): StreamResponse
+    {
+        return $this->post("users/restore", ["user_ids" => $userIds]);
+    }
+
     /** Deletes multiple users. This operation is asynchronous.
      * Use `$client->getTask` to check the status of the task.
      * @link https://getstream.io/chat/docs/php/channel_delete/?language=php


### PR DESCRIPTION
## Updates:
 
 - Add `restoreUsers` method to `Client.php`
  - Update inaccurate method comments in `Client.php`

---

## Code example for testing `restoreUsers`

The `restoreUsers` functionality can be tested with the following code after the commits are implemented:


```php
<?php

use GetStream\StreamChat\Client;

require_once "./vendor/autoload.php";

$client = new Client('<api-key>', '<api-secret>');

# Create users
$user_1 = [
    'id' => 'u-70', # Have to keep updating this between testing this out-- you cannot upsert a previously deleted user ID
    'role' => 'admin',
    'name' => 'Bob',
];

# Add users to Stream
$client->upsertUsers([$user_1]);

# Users Query Object
$queryUsersInput = [
    'id' => ['$in' => [$user_1['id']] ],
];

# SOFT-delete user
$delete_users_response = $client->deleteUsers([$user_1['id']], [
    'user' => 'soft',
    'messages' => 'soft'
]);

sleep(3); # Let the delete task complete before fetching it
$task = $client->getTask($delete_users_response['task_id']);

# Restore user once deleteTask is complete
if($task["status"] == "completed") {
    echo 'Now will try to restore a soft-deleted user...';

    $client->restoreUsers([$user_1['id']]);
    $users = $client->queryUsers($queryUsersInput)['users'];

    echo 'Queried Users: ' . PHP_EOL;
    var_dump($users);
}

# HARD-delete user
$delete_users_response = $client->deleteUsers([$user_1['id']], [
    'user' => 'hard',
    'messages' => 'hard'
]);

sleep(3); # Let the delete task complete before fetching it
$task = $client->getTask($delete_users_response['task_id']);

# Try to restore user once deleteTask is complete
if($task["status"] == "completed") {
    echo 'Now will try to restore a hard-deleted user...';
    $client->restoreUsers([$user_1['id']]);
    # 404 Errors out
}
```