### PR TITLE
[CHA-397]undelete message

### DIFF
--- a/lib/GetStream/StreamChat/Client.php
+++ b/lib/GetStream/StreamChat/Client.php
@@ -819,6 +819,16 @@ class Client
         return $this->delete("messages/" . $messageId, $options);
     }
 
+    /**
+     * Undeletes a message.
+     * @link https://getstream.io/chat/docs/php/send_message/?language=php
+     * @throws StreamException
+     */
+    public function undeleteMessage(string $messageId, string $userId): StreamResponse
+    {
+        return $this->post("messages/" . urlencode($messageId) . "/undelete", ["undeleted_by" => $userId]);
+    }
+
     /** Allows you to search for users and see if they are online/offline.
      * You can filter and sort on the custom fields you've set for your user, the user id, and when the user was last active.
      * @link https://getstream.io/chat/docs/php/query_users/?language=php

--- a/tests/integration/IntegrationTest.php
+++ b/tests/integration/IntegrationTest.php
@@ -563,6 +563,15 @@ class IntegrationTest extends TestCase
         $this->client->deleteMessage($msgId);
     }
 
+    public function testUnDeleteMessage()
+    {
+        $msgId = $this->generateGuid();
+        $msg = ["id" => $msgId, "text" => "helloworld"];
+        $this->channel->sendMessage($msg, $this->user1["id"]);
+        $this->client->deleteMessage($msgId);
+        $this->client->undeleteMessage($msgId, $this->user1["id"]);
+    }
+
     public function testManyMessages()
     {
         $msgId = $this->generateGuid();


### PR DESCRIPTION
This pull request introduces a new feature to undelete messages in the `StreamChat` client and includes corresponding tests. The most important changes include adding the `undeleteMessage` method and a new test case to verify its functionality.

New feature implementation:

* [`lib/GetStream/StreamChat/Client.php`](diffhunk://#diff-7f302ac38049dc9f1a8c5b3a8a13b7d99cb8dd5ae99ceadf8adaf6799323d2f5R822-R831): Added the `undeleteMessage` method to allow undeleting messages by their ID and the user who undeleted them.

