### PR TITLE
[CHA-794] Add Query Threads

### DIFF
--- a/lib/GetStream/StreamChat/Client.php
+++ b/lib/GetStream/StreamChat/Client.php
@@ -906,7 +906,8 @@ class Client
             }
         }
 
-        $options["filter"] = $filter;
+        $filterObject = (object)$filter;
+        $options["filter"] = $filterObject;
         $options["sort"] = $sortFields;
 
         return $this->post("threads", $options);

--- a/lib/GetStream/StreamChat/Client.php
+++ b/lib/GetStream/StreamChat/Client.php
@@ -898,17 +898,17 @@ class Client
         if ($options === null) {
             $options = [];
         }
-        
+
         $sortFields = [];
         if ($sort !== null) {
             foreach ($sort as $k => $v) {
                 $sortFields[] = ["field" => $k, "direction" => $v];
             }
         }
-        
+
         $options["filter"] = $filter;
         $options["sort"] = $sortFields;
-        
+
         return $this->post("threads", $options);
     }
 

--- a/lib/GetStream/StreamChat/Client.php
+++ b/lib/GetStream/StreamChat/Client.php
@@ -906,9 +906,19 @@ class Client
             }
         }
 
-        $filterObject = (object)$filter;
-        $options["filter"] = $filterObject;
-        $options["sort"] = $sortFields;
+
+        if (!empty($filter)) {
+            $filterObject = (object)$filter;
+            $options["filter"] = $filterObject;
+        } else {
+            $options["filter"] = null;
+        }
+
+        if (!empty($sortFields)) {
+            $options["sort"] = $sortFields;
+        } else {
+            $options["sort"] = null;
+        }
 
         return $this->post("threads", $options);
     }

--- a/lib/GetStream/StreamChat/Client.php
+++ b/lib/GetStream/StreamChat/Client.php
@@ -886,6 +886,33 @@ class Client
         return $this->post("channels", $options);
     }
 
+    /** Queries threads.
+     * You can query threads based on built-in fields as well as any custom field you add to threads.
+     * Multiple filters can be combined using AND, OR logical operators, each filter can use its
+     * comparison (equality, inequality, greater than, greater or equal, etc.).
+     * You can find the complete list of supported operators in the query syntax section of the docs.
+     * @link https://getstream.io/chat/docs/php/query_threads/?language=php
+     * @throws StreamException
+     */
+    public function queryThreads(array $filterConditions, ?array $sort = null, ?array $options = null): StreamResponse
+    {
+        if ($options === null) {
+            $options = [];
+        }
+        
+        $sortFields = [];
+        if ($sort !== null) {
+            foreach ($sort as $k => $v) {
+                $sortFields[] = ["field" => $k, "direction" => $v];
+            }
+        }
+        
+        $options["filter_conditions"] = $filterConditions;
+        $options["sort"] = $sortFields;
+        
+        return $this->post("threads", $options);
+    }
+
     /** Creates a channel type.
      * @link https://getstream.io/chat/docs/php/channel_features/?language=php
      * @throws StreamException

--- a/lib/GetStream/StreamChat/Client.php
+++ b/lib/GetStream/StreamChat/Client.php
@@ -888,13 +888,12 @@ class Client
 
     /** Queries threads.
      * You can query threads based on built-in fields as well as any custom field you add to threads.
-     * Multiple filters can be combined using AND, OR logical operators, each filter can use its
-     * comparison (equality, inequality, greater than, greater or equal, etc.).
+     * Multiple filters can be combined, each filter can use its comparison (equality, inequality, greater than, greater or equal, etc.).
      * You can find the complete list of supported operators in the query syntax section of the docs.
-     * @link https://getstream.io/chat/docs/php/query_threads/?language=php
+     * @link https://getstream.io/chat/docs/php/threads/#filtering-and-sorting-threads
      * @throws StreamException
      */
-    public function queryThreads(array $filterConditions, ?array $sort = null, ?array $options = null): StreamResponse
+    public function queryThreads(array $filter, ?array $sort = null, ?array $options = null): StreamResponse
     {
         if ($options === null) {
             $options = [];
@@ -907,7 +906,7 @@ class Client
             }
         }
         
-        $options["filter_conditions"] = $filterConditions;
+        $options["filter"] = $filter;
         $options["sort"] = $sortFields;
         
         return $this->post("threads", $options);

--- a/tests/integration/IntegrationTest.php
+++ b/tests/integration/IntegrationTest.php
@@ -1540,10 +1540,6 @@ class IntegrationTest extends TestCase
         // Verify the response
         $this->assertTrue(array_key_exists("threads", (array)$response));
         $this->assertGreaterThanOrEqual(1, count($response["threads"]));
-
-        // Clean up
-        $this->channel->deleteMessage($threadMessage["message"]["id"]);
-        $this->channel->deleteMessage($parentMessage["message"]["id"]);
     }
 
     public function testQueryThreadsWithSort()
@@ -1571,12 +1567,6 @@ class IntegrationTest extends TestCase
         // Verify the response
         $this->assertTrue(array_key_exists("threads", (array)$response));
         $this->assertGreaterThanOrEqual(2, count($response["threads"]));
-
-        // Clean up
-        $this->channel->deleteMessage($threadMessage1["message"]["id"]);
-        $this->channel->deleteMessage($parentMessage1["message"]["id"]);
-        $this->channel->deleteMessage($threadMessage2["message"]["id"]);
-        $this->channel->deleteMessage($parentMessage2["message"]["id"]);
     }
 
     public function testQueryThreadsWithFilterAndSort()
@@ -1604,12 +1594,6 @@ class IntegrationTest extends TestCase
         // Verify the response
         $this->assertTrue(array_key_exists("threads", (array)$response));
         $this->assertGreaterThanOrEqual(2, count($response["threads"]));
-
-        // Clean up
-        $this->channel->deleteMessage($threadMessage1["message"]["id"]);
-        $this->channel->deleteMessage($parentMessage1["message"]["id"]);
-        $this->channel->deleteMessage($threadMessage2["message"]["id"]);
-        $this->channel->deleteMessage($parentMessage2["message"]["id"]);
     }
 
     public function testQueryThreadsWithoutFilterAndSort()
@@ -1631,9 +1615,5 @@ class IntegrationTest extends TestCase
         // Verify the response
         $this->assertTrue(array_key_exists("threads", (array)$response));
         $this->assertGreaterThanOrEqual(1, count($response["threads"]));
-
-        // Clean up
-        $this->channel->deleteMessage($threadMessage["message"]["id"]);
-        $this->channel->deleteMessage($parentMessage["message"]["id"]);
     }
 }

--- a/tests/integration/IntegrationTest.php
+++ b/tests/integration/IntegrationTest.php
@@ -1532,7 +1532,9 @@ class IntegrationTest extends TestCase
         
         // Query threads with filter
         $response = $this->client->queryThreads(
-            ["parent_id" => ['$eq' => $parentMessage["message"]["id"]]]
+            ["parent_id" => ['$eq' => $parentMessage["message"]["id"]]],
+            null,
+            ["user_id" => $this->user1["id"]]
         );
         
         // Verify the response
@@ -1561,8 +1563,9 @@ class IntegrationTest extends TestCase
         
         // Query threads with sort
         $response = $this->client->queryThreads(
-            [], // No filter
-            ["created_at" => -1] // Sort by created_at descending
+            [],
+            ["created_at" => -1],
+            ["user_id" => $this->user1["id"]]
         );
         
         // Verify the response
@@ -1593,8 +1596,9 @@ class IntegrationTest extends TestCase
         
         // Query threads with both filter and sort
         $response = $this->client->queryThreads(
-            ["created_by_user_id" => ['$eq' => $this->user2["id"]]], // Filter by creator
-            ["created_at" => -1] // Sort by created_at descending
+            ["created_by_user_id" => ['$eq' => $this->user2["id"]]],
+            ["created_at" => -1],
+            ["user_id" => $this->user1["id"]]
         );
         
         // Verify the response

--- a/tests/integration/IntegrationTest.php
+++ b/tests/integration/IntegrationTest.php
@@ -1532,7 +1532,7 @@ class IntegrationTest extends TestCase
 
         // Query threads with filter
         $response = $this->client->queryThreads(
-            ["parent_id" => ['$eq' => $parentMessage["message"]["id"]]],
+            ["parent_message_id" => ['$eq' => $parentMessage["message"]["id"]]],
             null,
             ["user_id" => $this->user1["id"]]
         );


### PR DESCRIPTION
```
// First page of results
$response = $client->queryThreads(
    ["created_by_user_id" => ['$eq' => "user123"]], // Filter by creator
    ["created_at" => -1], // Sort by created_at descending
    [
        "user_id" => "user456", // User ID in options
        "limit" => 10 // Limit to 10 results per page
    ]
);

// Get the next page using the 'next' parameter
if (isset($response["next"])) {
    $nextPage = $client->queryThreads(
        ["created_by_user_id" => ['$eq' => "user123"]], // Same filter
        ["created_at" => -1], // Same sort
        [
            "user_id" => "user456", // Same user ID
            "limit" => 10, // Same limit
            "next" => $response["next"] // Use the 'next' value for pagination
        ]
    );
}
```