### PR TITLE
feat: add hide_history_before option for adding members

### DIFF
--- a/lib/GetStream/StreamChat/Channel.php
+++ b/lib/GetStream/StreamChat/Channel.php
@@ -4,6 +4,8 @@ declare(strict_types=0);
 
 namespace GetStream\StreamChat;
 
+use DateTime;
+
 /**
  * Class for handling Stream Chat Channels
  */
@@ -299,6 +301,10 @@ class Channel
             "add_members" => $userIds
         ];
         if ($options !== null) {
+            // Format hide_history_before DateTime to RFC 3339 if provided
+            if (isset($options["hide_history_before"]) && $options["hide_history_before"] instanceof DateTime) {
+                $options["hide_history_before"] = $options["hide_history_before"]->format(DateTime::RFC3339);
+            }
             $payload = array_merge($payload, $options);
         }
         return $this->update(null, null, $payload);


### PR DESCRIPTION
<!--
Here are some ideas to get you started:

  - [ ] Clearly explain what this PR does and why (link issues if relevant)
  - [ ] Follow best practices and conventions of the language and tools
  - [ ] Test your code changes (add some information if not applicable)

  -->

When adding members to a channel, it is now possible to not only hide all channel history for them (via hide_history), but also select a timestamp in the past via hide_history_before. Any activity before that will be hidden.

This PR adds an option to enable this feature.