### PR TITLE
[MOD2-818] Add delete_reactions support for ban user

### DIFF
--- a/tests/integration/IntegrationTest.php
+++ b/tests/integration/IntegrationTest.php
@@ -443,6 +443,14 @@ class IntegrationTest extends TestCase
         $this->client->banUser($this->user1["id"], ["user_id" => $this->user2["id"]]);
     }
 
+    public function testBanUserWithDeleteReactions()
+    {
+        $this->client->banUser($this->user1["id"], [
+            "user_id" => $this->user2["id"],
+            "delete_reactions" => true,
+        ]);
+    }
+
     public function testUnBanUser()
     {
         $this->client->banUser($this->user1["id"], ["user_id" => $this->user2["id"]]);


### PR DESCRIPTION
## Summary
- Adds test coverage for the new `delete_reactions` boolean parameter in the ban API
- The `delete_reactions` option removes all reactions by the banned user on other users' messages when set to `true`
- The PHP SDK uses an `$options` array pattern, so the parameter flows through automatically — only a test was needed

## Related
- Backend PR: https://github.com/GetStream/chat/pull/12495

## Checklist
- [x] The changed code has been covered with unit tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)