### PR TITLE
[CHA-3071] feat: decode gzip-compressed webhook bodies

### DIFF
--- a/lib/GetStream/StreamChat/Client.php
+++ b/lib/GetStream/StreamChat/Client.php
@@ -1224,13 +1224,70 @@ class Client
     }
 
     /** Verify the signature added to a webhook event.
+     *
+     * The signature is always computed over the uncompressed JSON body. When webhook
+     * compression is enabled on the app the request body must be decompressed (via
+     * {@see decompressWebhookBody()} or {@see verifyAndDecodeWebhook()}) before being
+     * passed to this method.
      * @throws StreamException
      */
     public function verifyWebhook(string $requestBody, string $XSignature): bool
     {
         $signature = hash_hmac("sha256", $requestBody, $this->apiSecret);
 
-        return $signature === $XSignature;
+        return hash_equals($signature, $XSignature);
+    }
+
+    /** Decompress the body of an outbound webhook according to its Content-Encoding header.
+     *
+     * This SDK only supports `gzip`. A null or empty encoding returns the body unchanged.
+     * Any other value raises a {@see StreamException} so callers can surface a clear error
+     * and the operator can flip the app back to `gzip` on the dashboard.
+     *
+     * @throws StreamException
+     */
+    public function decompressWebhookBody(string $body, ?string $contentEncoding): string
+    {
+        if ($contentEncoding === null) {
+            return $body;
+        }
+        $encoding = strtolower(trim($contentEncoding));
+        if ($encoding === '') {
+            return $body;
+        }
+        if ($encoding !== 'gzip') {
+            throw new StreamException(
+                'unsupported webhook Content-Encoding: ' . $contentEncoding
+                . '. This SDK only supports gzip; set webhook_compression_algorithm to "gzip"'
+                . ' on the app config.'
+            );
+        }
+        $decoded = @gzdecode($body);
+        if ($decoded === false) {
+            throw new StreamException('failed to gzip-decode webhook body');
+        }
+        return $decoded;
+    }
+
+    /** Decompresses (when Content-Encoding is set) and verifies the HMAC signature of an
+     * outbound webhook request, returning the raw JSON body when the signature matches.
+     *
+     * This is the recommended entry point for webhook handlers when webhook compression
+     * may be enabled on the app: it handles every value of `Content-Encoding` Stream may
+     * send and keeps signature verification on the uncompressed body.
+     *
+     * @throws StreamException if the signature does not match or the body cannot be decoded
+     */
+    public function verifyAndDecodeWebhook(
+        string $body,
+        string $signature,
+        ?string $contentEncoding
+    ): string {
+        $decoded = $this->decompressWebhookBody($body, $contentEncoding);
+        if (!$this->verifyWebhook($decoded, $signature)) {
+            throw new StreamException('invalid webhook signature');
+        }
+        return $decoded;
     }
 
     /** Searches for messages.

--- a/tests/unit/WebhookCompressionTest.php
+++ b/tests/unit/WebhookCompressionTest.php
@@ -1,0 +1,137 @@
+<?php
+
+declare(strict_types=0);
+
+namespace GetStream\Unit;
+
+use GetStream\StreamChat\Client;
+use GetStream\StreamChat\StreamException;
+use PHPUnit\Framework\TestCase;
+
+class WebhookCompressionTest extends TestCase
+{
+    private const API_KEY = 'key';
+    private const API_SECRET = 'tsec2';
+    private const JSON_BODY = '{"type":"message.new","message":{"text":"the quick brown fox"}}';
+
+    private Client $client;
+
+    public function setUp(): void
+    {
+        $this->client = new Client(self::API_KEY, self::API_SECRET);
+    }
+
+    private function sign(string $body): string
+    {
+        return hash_hmac('sha256', $body, self::API_SECRET);
+    }
+
+    public function testDecompressWebhookBodyPassthroughWhenEncodingNull(): void
+    {
+        $this->assertSame(self::JSON_BODY, $this->client->decompressWebhookBody(self::JSON_BODY, null));
+    }
+
+    public function testDecompressWebhookBodyPassthroughWhenEncodingEmpty(): void
+    {
+        $this->assertSame(self::JSON_BODY, $this->client->decompressWebhookBody(self::JSON_BODY, ''));
+        $this->assertSame(self::JSON_BODY, $this->client->decompressWebhookBody(self::JSON_BODY, '   '));
+    }
+
+    public function testDecompressWebhookBodyRoundTripsGzip(): void
+    {
+        $compressed = gzencode(self::JSON_BODY);
+        $this->assertNotFalse($compressed);
+        $this->assertNotEquals(self::JSON_BODY, $compressed);
+
+        $this->assertSame(self::JSON_BODY, $this->client->decompressWebhookBody($compressed, 'gzip'));
+    }
+
+    public function testDecompressWebhookBodyHandlesEncodingCaseInsensitively(): void
+    {
+        $compressed = gzencode(self::JSON_BODY);
+        $this->assertSame(self::JSON_BODY, $this->client->decompressWebhookBody($compressed, 'GZIP'));
+        $this->assertSame(self::JSON_BODY, $this->client->decompressWebhookBody($compressed, '  gzip  '));
+    }
+
+    /**
+     * @dataProvider nonGzipEncodings
+     */
+    public function testDecompressWebhookBodyRejectsEveryNonGzipEncoding(string $encoding): void
+    {
+        try {
+            $this->client->decompressWebhookBody(self::JSON_BODY, $encoding);
+            $this->fail("expected StreamException for encoding '$encoding'");
+        } catch (StreamException $e) {
+            $this->assertStringContainsString('unsupported', $e->getMessage());
+            $this->assertStringContainsString('gzip', $e->getMessage());
+        }
+    }
+
+    public static function nonGzipEncodings(): array
+    {
+        return [
+            'brotli short' => ['br'],
+            'brotli long'  => ['brotli'],
+            'zstd'         => ['zstd'],
+            'deflate'      => ['deflate'],
+            'compress'     => ['compress'],
+            'lz4'          => ['lz4'],
+        ];
+    }
+
+    public function testDecompressWebhookBodyThrowsOnInvalidGzipBytes(): void
+    {
+        $this->expectException(StreamException::class);
+        $this->expectExceptionMessageMatches('/failed to gzip-decode/');
+        $this->client->decompressWebhookBody('not actually gzip', 'gzip');
+    }
+
+    public function testVerifyWebhookUsesConstantTimeComparison(): void
+    {
+        $sig = $this->sign(self::JSON_BODY);
+        $this->assertTrue($this->client->verifyWebhook(self::JSON_BODY, $sig));
+        $this->assertFalse($this->client->verifyWebhook(self::JSON_BODY, 'deadbeef'));
+    }
+
+    public function testVerifyAndDecodeWebhookGzipHappyPath(): void
+    {
+        $compressed = gzencode(self::JSON_BODY);
+        $sig = $this->sign(self::JSON_BODY);
+
+        $decoded = $this->client->verifyAndDecodeWebhook($compressed, $sig, 'gzip');
+        $this->assertSame(self::JSON_BODY, $decoded);
+    }
+
+    public function testVerifyAndDecodeWebhookPassthroughHappyPath(): void
+    {
+        $sig = $this->sign(self::JSON_BODY);
+
+        $this->assertSame(
+            self::JSON_BODY,
+            $this->client->verifyAndDecodeWebhook(self::JSON_BODY, $sig, null)
+        );
+        $this->assertSame(
+            self::JSON_BODY,
+            $this->client->verifyAndDecodeWebhook(self::JSON_BODY, $sig, '')
+        );
+    }
+
+    public function testVerifyAndDecodeWebhookThrowsOnSignatureMismatch(): void
+    {
+        $compressed = gzencode(self::JSON_BODY);
+
+        $this->expectException(StreamException::class);
+        $this->expectExceptionMessageMatches('/invalid webhook signature/');
+        $this->client->verifyAndDecodeWebhook($compressed, 'deadbeef', 'gzip');
+    }
+
+    public function testVerifyAndDecodeWebhookRejectsSignatureOverCompressedBytes(): void
+    {
+        $compressed = gzencode(self::JSON_BODY);
+        $sigOverCompressed = hash_hmac('sha256', $compressed, self::API_SECRET);
+
+        $this->expectException(StreamException::class);
+        $this->expectExceptionMessageMatches('/invalid webhook signature/');
+        $this->client->verifyAndDecodeWebhook($compressed, $sigOverCompressed, 'gzip');
+    }
+}


### PR DESCRIPTION
## Ticket
- https://linear.app/stream/issue/CHA-3071/compress-webhook-payloads

## Summary

Server-side webhook compression is landing in [GetStream/chat#13222](https://github.com/GetStream/chat/pull/13222). When an app opts in (`webhook_compression_algorithm = \"gzip\"`) every outbound webhook body is gzipped and a `Content-Encoding: gzip` header is added. `X-Signature` is still computed over the **uncompressed** JSON, so handlers must decompress before verifying.

This PR adds the customer-side primitives so handlers built on this SDK keep working when their app gets flipped on.

## What's new

- `Client::decompressWebhookBody(string $body, ?string $contentEncoding): string`
  - `null` / `''` / whitespace → returns body unchanged.
  - `gzip` (case-insensitive, trimmed) → `gzdecode`.
  - Anything else → `StreamException` with a message that names the offending encoding and points the operator back at `webhook_compression_algorithm`.
- `Client::verifyAndDecodeWebhook(string $body, string $signature, ?string $contentEncoding): string`
  - Decompresses (if needed), verifies HMAC over the uncompressed bytes, and returns the raw JSON. Throws `StreamException` on signature mismatch.
- `Client::verifyWebhook` now uses `hash_equals` instead of `===` so the signature comparison is constant-time. Public surface is unchanged.

The SDK supports **gzip only**. Any other `Content-Encoding` (`br`, `zstd`, `deflate`, …) raises a clear error rather than silently dropping the body.

## Tests

`tests/unit/WebhookCompressionTest.php` (16 cases under the unit suite, 20 total in the suite):

- gzip round-trip
- passthrough on `null`, empty, whitespace
- case-insensitive + trimmed encoding header
- six-row data provider rejecting `br`, `brotli`, `zstd`, `deflate`, `compress`, `lz4` with the expected hint
- corrupted gzip bytes → `failed to gzip-decode`
- `verifyWebhook` constant-time true / false
- `verifyAndDecodeWebhook` happy paths (gzip + passthrough), bad signature, and the regression case where the signature was computed over the compressed bytes (must reject).

```
docker run --rm -v \"\$(pwd)\":/app -w /app php:8.2-cli vendor/bin/phpunit --testsuite='Unit Test Suite'
...
OK (20 tests, 37 assertions)
```

`vendor/bin/php-cs-fixer fix --dry-run --diff` clean on the touched files.

## Backward compatibility

- No change to existing callers. `verifyWebhook(\$body, \$signature)` keeps the same signature and behavior; the only difference is the comparison is now constant-time.
- New methods are additive.
- No new dependencies — gzip uses the built-in `zlib` extension.

Made with [Cursor](https://cursor.com)